### PR TITLE
Target vscode version is 1.39.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.2.0",
   "publisher": "Compulim",
   "engines": {
-    "vscode": "^0.10.8"
+    "vscode": "^1.39.0"
   },
   "icon": "icon.png",
   "galleryBanner.color": "#0D5CAB",
@@ -25,7 +25,7 @@
   "activationEvents": [
     "onCommand:qrcode.generateFromSelected"
   ],
-  "main": "./extension",
+  "main": "./extension.js",
   "contributes": {
     "commands": [
       {
@@ -35,10 +35,10 @@
     ]
   },
   "devDependencies": {
-    "vscode": "^0.11.x"
+    "@types/vscode": "^1.39.0"
   },
   "dependencies": {
-    "q": "^1.4.1",
-    "qrcode-generator": "^1.0.0"
+    "q": "^1.5.1",
+    "qrcode-generator": "^1.4.4"
   }
 }


### PR DESCRIPTION
With the current vscode 1.39, the QR Code preview is not displayed.
This is because `vscode.previewHtml` has been deprecated.
Use `WebviewPanel` instead of` vscode.previewHtml`,
Each component has also been updated.